### PR TITLE
chore: drop (explicit) support for Node v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - stable
-  - lts/carbon
   - lts/dubnium
 branches:
   only:


### PR DESCRIPTION
Node LTS Carbon will no longer be tested in CI. It may work. It may not.

BREAKING CHANGE: Drop support for Node v8